### PR TITLE
Target distribution

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 2%
+        base: auto      
+    patch:
+      default:
+        informational: true 

--- a/docs/src/man/system.md
+++ b/docs/src/man/system.md
@@ -18,7 +18,7 @@ end
 ```
 - Target density: This is the (unnormalised) log-density of the system. In this case it's simply the Boltzmann distribution at inverse temperature $\beta$. Note that it takes a generic state as input instead of the whole system object. This is better for performance, as generally the density only depends on a few properties of the system. In this case `state` is a tuple defined as `(e, β)`.
 ```julia
-function Arianna.unnormalised_log_target_density(state)
+function Arianna.unnormalised_log_target_density(state, ::Particle)
     return -state[2] * state[1]
 end
 ```

--- a/docs/src/man/system.md
+++ b/docs/src/man/system.md
@@ -19,7 +19,7 @@ end
 - Target density: This is the (unnormalised) log-density of the system. In this case it's simply the Boltzmann distribution at inverse temperature $\beta$. Note that it takes a generic state as input instead of the whole system object. This is better for performance, as generally the density only depends on a few properties of the system. In this case `state` is a tuple defined as `(e, β)`.
 ```julia
 function Arianna.unnormalised_log_target_density(state, ::Particle)
-    return -state[2] * state[1]
+    return -state[1] * state[2]
 end
 ```
 

--- a/docs/src/man/system.md
+++ b/docs/src/man/system.md
@@ -16,10 +16,10 @@ mutable struct Particle{T<:AbstractFloat}
     e::T
 end
 ```
-- Target density ratio: This is the log-density ratio of the system before and after a Monte Carlo move. It is needed to determine the acceptance probability in the Metropolis algorithm. In this case the target is the Boltzmann distribution at inverse temperature $\beta$.
+- Target density: This is the (unnormalised) log-density of the system. In this case it's simply the Boltzmann distribution at inverse temperature $\beta$. Note that it takes a generic state as input instead of the whole system object. This is better for performance, as generally the density only depends on a few properties of the system. In this case `state` is a tuple defined as `(e, β)`.
 ```julia
-function Arianna.delta_log_target_density(e₁, e₂, system::Particle)
-    return -system.β * (e₂ - e₁)
+function Arianna.unnormalised_log_target_density(state)
+    return -state[2] * state[1]
 end
 ```
 
@@ -52,7 +52,7 @@ function Arianna.perform_action!(system::Particle, action::Displacement)
     e₁ = system.e
     system.x += action.δ
     system.e = potential(system.x)
-    return e₁, system.e
+    return (e₁, system.β), (system.e, system.β)
 end
 ```
 

--- a/example/particle_1d/particle_1d.jl
+++ b/example/particle_1d/particle_1d.jl
@@ -18,7 +18,7 @@ end
 System(x, β) = Particle(x, β)
 
 function Arianna.unnormalised_log_target_density(state, ::Particle)
-    return -state[2] * state[1]
+    return -state[1] * state[2]
 end
 
 ###############################################################################

--- a/example/particle_1d/particle_1d.jl
+++ b/example/particle_1d/particle_1d.jl
@@ -17,7 +17,7 @@ end
 
 System(x, β) = Particle(x, β)
 
-function Arianna.unnormalised_log_target_density(state::Tuple)
+function Arianna.unnormalised_log_target_density(state, ::Particle)
     return -state[2] * state[1]
 end
 

--- a/example/particle_1d/particle_1d.jl
+++ b/example/particle_1d/particle_1d.jl
@@ -17,8 +17,8 @@ end
 
 System(x, β) = Particle(x, β)
 
-function Arianna.delta_log_target_density(e₁, e₂, system::Particle)
-    return -system.β * (e₂ - e₁)
+function Arianna.unnormalised_log_target_density(state::Tuple)
+    return -state[2] * state[1]
 end
 
 ###############################################################################
@@ -31,7 +31,7 @@ function Arianna.perform_action!(system::Particle, action::Displacement)
     e₁ = system.e
     system.x += action.δ
     system.e = potential(system.x)
-    return e₁, system.e
+    return (e₁, system.β), (system.e, system.β)
 end
 
 function Arianna.invert_action!(action::Displacement, system::Particle)

--- a/src/PolicyGuided/gradients.jl
+++ b/src/PolicyGuided/gradients.jl
@@ -48,7 +48,7 @@ function pgmc_estimate(action::Action, policy::Policy, parameters::AbstractArray
     ∇logq_backward .= zero(parameters)
     logq_forward = withgrad_log_proposal_density!(∇logq_forward, action, policy, parameters, system, ad_backend; shadow=shadow)
     x₁, x₂ = perform_action!(system, action)
-    Δlogp = delta_log_target_density(x₁, x₂)
+    Δlogp = delta_log_target_density(x₁, x₂, system)
     r = reward(action, system)
     invert_action!(action, system)
     logq_backward = withgrad_log_proposal_density!(∇logq_backward, action, policy, parameters, system, ad_backend; shadow=shadow)

--- a/src/PolicyGuided/gradients.jl
+++ b/src/PolicyGuided/gradients.jl
@@ -48,7 +48,7 @@ function pgmc_estimate(action::Action, policy::Policy, parameters::AbstractArray
     ∇logq_backward .= zero(parameters)
     logq_forward = withgrad_log_proposal_density!(∇logq_forward, action, policy, parameters, system, ad_backend; shadow=shadow)
     x₁, x₂ = perform_action!(system, action)
-    Δlogp = delta_log_target_density(x₁, x₂, system)
+    Δlogp = delta_log_target_density(x₁, x₂)
     r = reward(action, system)
     invert_action!(action, system)
     logq_backward = withgrad_log_proposal_density!(∇logq_backward, action, policy, parameters, system, ad_backend; shadow=shadow)

--- a/src/metropolis.jl
+++ b/src/metropolis.jl
@@ -2,11 +2,12 @@ abstract type Action end
 
 abstract type Policy end
 
+raise_error(s) = error("No $s is defined")
 sample_action!(action::Action, policy::Policy, parameters, system, rng) = raise_error("sample_action!")
 log_proposal_density(action, policy, parameters, system) = raise_error("log_proposal_density")
 perform_action!(system, action::Action) = raise_error("perform_action!")
-unnormalised_log_target_density(x) = raise_error("unnormalised_log_target_density")
-delta_log_target_density(x₁, x₂) = unnormalised_log_target_density(x₂) - unnormalised_log_target_density(x₁)
+unnormalised_log_target_density(x, system) = raise_error("unnormalised_log_target_density")
+delta_log_target_density(x₁, x₂, system) = unnormalised_log_target_density(x₂, system) - unnormalised_log_target_density(x₁, system)
 invert_action!(action::Action, system) = raise_error("invert_action!")
 perform_action_cached!(system, action::Action) = perform_action!(system, action)
 
@@ -27,7 +28,7 @@ function mc_step!(system, action::Action, policy::Policy, parameters::AbstractAr
     sample_action!(action, policy, parameters, system, rng)
     logq_forward = log_proposal_density(action, policy, parameters, system)
     x₁, x₂ = perform_action!(system, action)
-    Δlogp = delta_log_target_density(x₁, x₂)
+    Δlogp = delta_log_target_density(x₁, x₂, system)
     invert_action!(action, system)
     logq_backward = log_proposal_density(action, policy, parameters, system)
     α = min(one(T), exp(Δlogp + logq_backward - logq_forward))

--- a/src/metropolis.jl
+++ b/src/metropolis.jl
@@ -2,11 +2,11 @@ abstract type Action end
 
 abstract type Policy end
 
-raise_error(s) = error("No $s is defined")
 sample_action!(action::Action, policy::Policy, parameters, system, rng) = raise_error("sample_action!")
 log_proposal_density(action, policy, parameters, system) = raise_error("log_proposal_density")
 perform_action!(system, action::Action) = raise_error("perform_action!")
-delta_log_target_density(x1, x2, system) = raise_error("delta_log_target_density")
+unnormalised_log_target_density(x) = raise_error("unnormalised_log_target_density")
+delta_log_target_density(x₁, x₂) = unnormalised_log_target_density(x₂) - unnormalised_log_target_density(x₁)
 invert_action!(action::Action, system) = raise_error("invert_action!")
 perform_action_cached!(system, action::Action) = perform_action!(system, action)
 
@@ -27,7 +27,7 @@ function mc_step!(system, action::Action, policy::Policy, parameters::AbstractAr
     sample_action!(action, policy, parameters, system, rng)
     logq_forward = log_proposal_density(action, policy, parameters, system)
     x₁, x₂ = perform_action!(system, action)
-    Δlogp = delta_log_target_density(x₁, x₂, system)
+    Δlogp = delta_log_target_density(x₁, x₂)
     invert_action!(action, system)
     logq_backward = log_proposal_density(action, policy, parameters, system)
     α = min(one(T), exp(Δlogp + logq_backward - logq_forward))


### PR DESCRIPTION
The way we used to define `delta_log_target_density` wasn't user friendly as it depended both on the "state" returned by `perform_action!` and from the system. We now introduce a new function named `unnormalised_log_target_density` which takes a "state" as input and the system object is used just for multiple dispatch. Here's an example in `particle_1D`: the state is a tuple `(energy, β)`.

```
function Arianna.unnormalised_log_target_density(state, ::Particle)
    return -state[2] * state[1]
end
```

```
function Arianna.perform_action!(system::Particle, action::Displacement)
    e₁ = system.e
    system.x += action.δ
    system.e = potential(system.x)
    return (e₁, system.β), (system.e, system.β)
end
```

The change shouldn't be a problem for backward compatibility.