### PR TITLE
AriannaSystem abstract type

### DIFF
--- a/example/particle_1d/particle_1d.jl
+++ b/example/particle_1d/particle_1d.jl
@@ -6,7 +6,7 @@ using ComponentArrays
 
 ###############################################################################
 ## SYSTEM
-mutable struct Particle{T<:AbstractFloat}
+mutable struct Particle{T<:AbstractFloat} <: AriannaSystem
     x::T
     β::T
     e::T

--- a/ext/EnzymeExt.jl
+++ b/ext/EnzymeExt.jl
@@ -5,7 +5,7 @@ using Enzyme
 
 struct Enzyme_Backend <: Arianna.PolicyGuided.AD_Backend end
 
-function Arianna.PolicyGuided.withgrad_log_proposal_density!(∇logq::T, action::Action, policy::Policy, parameters::T, system, ::Enzyme_Backend;
+function Arianna.PolicyGuided.withgrad_log_proposal_density!(∇logq::T, action::Action, policy::Policy, parameters::T, system::Arianna.AriannaSystem, ::Enzyme_Backend;
     shadow=deepcopy(system)) where {T<:AbstractArray}
     _, logq = Enzyme.autodiff(
         Enzyme.ReverseWithPrimal,

--- a/ext/ZygoteExt.jl
+++ b/ext/ZygoteExt.jl
@@ -5,7 +5,7 @@ using Zygote
 
 struct Zygote_Backend <: Arianna.PolicyGuided.AD_Backend end
 
-function Arianna.PolicyGuided.withgrad_log_proposal_density!(∇logq::T, action::Action, policy::Policy, parameters::T, system, ::Zygote_Backend;
+function Arianna.PolicyGuided.withgrad_log_proposal_density!(∇logq::T, action::Action, policy::Policy, parameters::T, system::Arianna.AriannaSystem, ::Zygote_Backend;
     shadow=missing) where {T<:AbstractArray}
     logq, gd = Zygote.withgradient(x -> log_proposal_density(action, policy, x, system), parameters)
     ∇logq .= gd[1]

--- a/src/Arianna.jl
+++ b/src/Arianna.jl
@@ -14,6 +14,14 @@ using Transducers
 using Dates
 using Printf
 
+"""
+    abstract type AriannaSystem
+
+Abstract type representing a system that can be simulated using methods defined in the `Arianna` module.
+"""
+abstract type AriannaSystem end
+export AriannaSystem
+
 include("simulation.jl")
 export Simulation, build_schedule, run!
 

--- a/src/PolicyGuided/PolicyGuided.jl
+++ b/src/PolicyGuided/PolicyGuided.jl
@@ -5,7 +5,7 @@ Module for policy-guided Monte Carlo algorithms.
 """
 module PolicyGuided
 
-using ..Arianna: Action, Policy, Algorithm, Simulation, Metropolis
+using ..Arianna: AriannaSystem, Action, Policy, Algorithm, Simulation, Metropolis
 import ..Arianna: make_step!, write_algorithm, sample_action!, perform_action!, delta_log_target_density, log_proposal_density, invert_action!, perform_action_cached!, raise_error
 using Random
 using LinearAlgebra

--- a/src/PolicyGuided/gradients.jl
+++ b/src/PolicyGuided/gradients.jl
@@ -13,19 +13,19 @@ Backend for automatic differentiation using ForwardDiff.jl.
 struct ForwardDiff_Backend <: AD_Backend end
 
 """
-    reward(action::Action, system)
+    reward(action::Action, system::AriannaSystem)
 
 Compute the reward for an action in a given system.
 """
-reward(action::Action, system) = Arianna.raise_error("reward")
+reward(action::Action, system::AriannaSystem) = Arianna.raise_error("reward")
 
 """
-    withgrad_log_proposal_density!(∇logq::T, action::Action, policy::Policy, parameters::T, system, ::ForwardDiff_Backend;
+    withgrad_log_proposal_density!(∇logq::T, action::Action, policy::Policy, parameters::T, system::AriannaSystem, ::ForwardDiff_Backend;
     shadow=missing) where {T<:AbstractArray}
 
 Compute the gradient of the log proposal density for an action in a given system using ForwardDiff.jl.
 """
-function withgrad_log_proposal_density!(∇logq::T, action::Action, policy::Policy, parameters::T, system, ::ForwardDiff_Backend;
+function withgrad_log_proposal_density!(∇logq::T, action::Action, policy::Policy, parameters::T, system::AriannaSystem, ::ForwardDiff_Backend;
     shadow=missing) where {T<:AbstractArray}
     logq = log_proposal_density(action, policy, parameters, system)
     ∇logq .= ForwardDiff.gradient(p -> log_proposal_density(action, policy, p, system), parameters)
@@ -85,12 +85,12 @@ function average(gd::GradientData)
 end
 
 """
-    pgmc_estimate(action::Action, policy::Policy, parameters::AbstractArray{T}, system;
+    pgmc_estimate(action::Action, policy::Policy, parameters::AbstractArray{T}, system::AriannaSystem;
     ∇logq_forward=zero(parameters), ∇logq_backward=zero(parameters), shadow=deepcopy(system), ad_backend::AD_Backend=ForwardDiff_Backend()) where {T<:AbstractFloat}
 
 Estimate the gradient of the objective function using policy gradient Monte Carlo.
 """
-function pgmc_estimate(action::Action, policy::Policy, parameters::AbstractArray{T}, system;
+function pgmc_estimate(action::Action, policy::Policy, parameters::AbstractArray{T}, system::AriannaSystem;
     ∇logq_forward=zero(parameters), ∇logq_backward=zero(parameters), shadow=deepcopy(system), ad_backend::AD_Backend=ForwardDiff_Backend()) where {T<:AbstractFloat}
     ∇logq_forward .= zero(parameters)
     ∇logq_backward .= zero(parameters)
@@ -109,12 +109,12 @@ function pgmc_estimate(action::Action, policy::Policy, parameters::AbstractArray
 end
 
 """
-    sample_gradient_data(action::Action, policy::Policy, parameters::AbstractArray, system, rng;
+    sample_gradient_data(action::Action, policy::Policy, parameters::AbstractArray, system::AriannaSystem, rng;
     ∇logq_forward=zero(parameters), ∇logq_backward=zero(parameters), shadow=deepcopy(system), ad_backend::AD_Backend=ForwardDiff_Backend())
 
 Sample gradient data for a given action, policy, parameters, and system.
 """
-function sample_gradient_data(action::Action, policy::Policy, parameters::AbstractArray, system, rng;
+function sample_gradient_data(action::Action, policy::Policy, parameters::AbstractArray, system::AriannaSystem, rng;
     ∇logq_forward=zero(parameters), ∇logq_backward=zero(parameters), shadow=deepcopy(system), ad_backend::AD_Backend=ForwardDiff_Backend())
     sample_action!(action, policy, parameters, system, rng)
     return pgmc_estimate(action, policy, parameters, system; ∇logq_forward=∇logq_forward, ∇logq_backward=∇logq_backward, shadow=shadow, ad_backend=ad_backend)

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -179,11 +179,11 @@ function StoreTrajectories(chains; path=missing, fmt=DAT(), store_first=true, st
 end
 
 """
-    store_trajectory(io, system, t, fmt::Format)
+    store_trajectory(io, system::AriannaSystem, t, fmt::Format)
 
 Store the system trajectory at time t to the given IO stream in the specified format.
 """
-function store_trajectory(io, system, t, fmt::Format)
+function store_trajectory(io, system::AriannaSystem, t, fmt::Format)
     println(io, "$t, $system")
     return nothing
 end
@@ -235,7 +235,7 @@ function StoreLastFrames(chains; path=missing, fmt=DAT(), extras...)
     return StoreLastFrames(chains, path, fmt)
 end
 
-store_lastframe(io, system, t, fmt::Format) = store_trajectory(io, system, t, fmt)
+store_lastframe(io, system::AriannaSystem, t, fmt::Format) = store_trajectory(io, system, t, fmt)
 """
     store_lastframe(io, system, t, fmt::Format)
 
@@ -278,7 +278,7 @@ function StoreBackups(chains; path=missing, fmt=DAT(), store_first=false, store_
     return StoreBackups(chains, path, fmt, store_first=store_first, store_last=store_last)
 end
 
-store_backup(io, system, t, fmt::Format) = store_trajectory(io, system, t, fmt)
+store_backup(io, system::AriannaSystem, t, fmt::Format) = store_trajectory(io, system, t, fmt)
 """
     store_backup(io, system, t, fmt::Format)
 

--- a/src/metropolis.jl
+++ b/src/metropolis.jl
@@ -35,7 +35,7 @@ Helper function to raise errors for unimplemented required methods.
 raise_error(s) = error("No $s is defined")
 
 """
-    sample_action!(action::Action, policy::Policy, parameters, system, rng)
+    sample_action!(action::Action, policy::Policy, parameters, system::AriannaSystem, rng)
 
 Sample a new action from the policy.
 
@@ -46,10 +46,10 @@ Sample a new action from the policy.
 - `system`: System the action will be applied to
 - `rng`: Random number generator
 """
-sample_action!(action::Action, policy::Policy, parameters, system, rng) = raise_error("sample_action!")
+sample_action!(action::Action, policy::Policy, parameters, system::AriannaSystem, rng) = raise_error("sample_action!")
 
 """
-    log_proposal_density(action, policy, parameters, system)
+    log_proposal_density(action, policy, parameters, system::AriannaSystem)
 
 Calculate the log probability density of proposing the given action.
 
@@ -59,10 +59,10 @@ Calculate the log probability density of proposing the given action.
 - `parameters`: Parameters of the policy
 - `system`: System the action is applied to
 """
-log_proposal_density(action, policy, parameters, system) = raise_error("log_proposal_density")
+log_proposal_density(action, policy, parameters, system::AriannaSystem) = raise_error("log_proposal_density")
 
 """
-    perform_action!(system, action::Action)
+    perform_action!(system::AriannaSystem, action::Action)
 
 Apply the action to modify the system state.
 
@@ -73,7 +73,7 @@ Apply the action to modify the system state.
 # Returns
 A tuple of (x₁, x₂) containing the old and new states
 """
-perform_action!(system, action::Action) = raise_error("perform_action!")
+perform_action!(system::AriannaSystem, action::Action) = raise_error("perform_action!")
 
 """
     unnormalised_log_target_density(x, system)
@@ -84,9 +84,9 @@ Calculate the unnormalized log probability density of a system state.
 - `x`: System state
 - `system`: System object
 """
-unnormalised_log_target_density(x, system) = raise_error("unnormalised_log_target_density")
+unnormalised_log_target_density(x, system::AriannaSystem) = raise_error("unnormalised_log_target_density")
 """
-    delta_log_target_density(x₁, x₂, system)
+    delta_log_target_density(x₁, x₂, system::AriannaSystem)
 
 Calculate the change in log target density between two states.
 
@@ -95,9 +95,9 @@ Calculate the change in log target density between two states.
 - `x₂`: Final state
 - `system`: System object
 """
-delta_log_target_density(x₁, x₂, system) = unnormalised_log_target_density(x₂, system) - unnormalised_log_target_density(x₁, system)
+delta_log_target_density(x₁, x₂, system::AriannaSystem) = unnormalised_log_target_density(x₂, system) - unnormalised_log_target_density(x₁, system)
 """
-    invert_action!(action::Action, system)
+    invert_action!(action::Action, system::AriannaSystem)
 
 Invert/reverse an action.
 
@@ -105,7 +105,7 @@ Invert/reverse an action.
 - `action`: Action to invert
 - `system`: System the action was applied to
 """
-invert_action!(action::Action, system) = raise_error("invert_action!")
+invert_action!(action::Action, system::AriannaSystem) = raise_error("invert_action!")
 
 """
     perform_action_cached!(system, action::Action)
@@ -116,7 +116,7 @@ Optimized version of perform_action! that can reuse cached values.
 - `system`: System to modify
 - `action`: Action to perform
 """
-perform_action_cached!(system, action::Action) = perform_action!(system, action)
+perform_action_cached!(system::AriannaSystem, action::Action) = perform_action!(system, action)
 
 """
     Move{A<:Action,P<:Policy,V<:AbstractArray,T<:AbstractFloat}
@@ -162,7 +162,7 @@ function Move(action, policy, parameters, weight)
 end
 
 """
-    mc_step!(system, action::Action, policy::Policy, parameters::AbstractArray{T}, rng) where {T<:AbstractFloat}
+    mc_step!(system::AriannaSystem, action::Action, policy::Policy, parameters::AbstractArray{T}, rng) where {T<:AbstractFloat}
 
 Perform a single Monte Carlo step.
 
@@ -173,7 +173,7 @@ Perform a single Monte Carlo step.
 - `parameters`: Parameters of the policy
 - `rng`: Random number generator
 """
-function mc_step!(system, action::Action, policy::Policy, parameters::AbstractArray{T}, rng) where {T<:AbstractFloat}
+function mc_step!(system::AriannaSystem, action::Action, policy::Policy, parameters::AbstractArray{T}, rng) where {T<:AbstractFloat}
     sample_action!(action, policy, parameters, system, rng)
     logq_forward = log_proposal_density(action, policy, parameters, system)
     x₁, x₂ = perform_action!(system, action)
@@ -190,7 +190,7 @@ function mc_step!(system, action::Action, policy::Policy, parameters::AbstractAr
 end
 
 """
-    mc_sweep!(system, pool, rng; mc_steps=1)
+    mc_sweep!(system::AriannaSystem, pool, rng; mc_steps=1)
 
 Perform a Monte Carlo sweep over a pool of moves.
 
@@ -200,7 +200,7 @@ Perform a Monte Carlo sweep over a pool of moves.
 - `rng`: Random number generator
 - `mc_steps`: Number of Monte Carlo steps per sweep
 """
-function mc_sweep!(system, pool, rng; mc_steps=1)
+function mc_sweep!(system::AriannaSystem, pool, rng; mc_steps=1)
     weights = [move.weight for move in pool]
     for _ in 1:mc_steps
         id = rand(rng, Categorical(weights))
@@ -244,7 +244,7 @@ struct Metropolis{P,R<:AbstractRNG,C<:Function} <: Algorithm
         seed::Int=1,
         R::DataType=Xoshiro,
         parallel::Bool=false
-    ) where {S,P}
+    ) where {S<:AriannaSystem,P}
         # Safety checks
         @assert length(chains) == length(pools)
         @assert all(k -> all(move -> move.parameters == getindex.(pools, k)[1].parameters, getindex.(pools, k)), eachindex(pools[1]))

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -4,7 +4,7 @@
 A structure representing a Monte Carlo simulation.
 
 # Fields
-- `chains::Vector{S}`: Vector of independent systems.
+- `chains::Vector{S}`: Vector of independent Arianna systems.
 - `algorithms::A`: List of algorithms.
 - `steps::Int`: Number of MC sweeps.
 - `t::Int`: Current time step.
@@ -27,7 +27,7 @@ mutable struct Simulation{S,A,VS}
     Create a new `Simulation` instance.
 
     # Arguments
-    - `chains::Vector{S}`: Vector of independent systems.
+    - `chains::Vector{S}`: Vector of independent Arianna systems.
     - `algorithms::A`: List of algorithms.
     - `schedulers::VS`: List of schedulers (one for each algorithm).
     - `steps::Int`: Number of MC sweeps.
@@ -41,7 +41,7 @@ mutable struct Simulation{S,A,VS}
         steps::Int;
         path::String="data",
         verbose::Bool=false
-    ) where {S,A,VS}
+    ) where {S<:AriannaSystem,A,VS}
         @assert length(schedulers) == length(algorithms)
         @assert all(scheduler -> all(x -> 0 ≤ x ≤ steps, scheduler), schedulers)
         @assert all(scheduler -> issorted(scheduler), schedulers)
@@ -59,7 +59,7 @@ end
 Create a new `Simulation` instance from a list of algorithm constructors.
 
 # Arguments
-- `chains`: Vector of independent systems.
+- `chains`: Vector of independent Arianna systems.
 - `algorithm_list`: List of algorithm constructors.
 - `steps`: Number of MC sweeps.
 - `path="data"`: Simulation path.
@@ -116,7 +116,7 @@ function build_schedule(steps::Int, burn::Int, block::Vector{Int})
     return filter(x -> x ≤ steps, unique(vcat(blocks..., [steps])))
 end
 
-function write_system(io, system)
+function write_system(io, system::AriannaSystem)
     println(io, "\t" * "$(typeof(system))")
     return nothing
 end


### PR DESCRIPTION
We create an new abstract type: `AriannaSystem` such as all systems that are simulated using `Arianna` have to be of concrete subtype of  `AriannaSystem`.